### PR TITLE
Fix pikaday

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-moment-shim": "^3.0.1",
-    "pikaday": "^1.5.1"
+    "pikaday": "1.6.1"
   },
   "ember-addon": {
     "after": [

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "author": "Matthew Dahl (https://github.com/sandersky)",
   "license": "MIT",
   "devDependencies": {
+    "bower": "^1.8.2",
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "2.12.3",
     "ember-cli-chai": "^0.3.2",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

This change is due to this error is showing up downstream after the release of version `1.7.0` of `pikday`:

```
The Broccoli Plugin: [Funnel: Funnel: compileAddon] failed with:
SyntaxError: pikaday/pikaday.js: 'import' and 'export' may only appear at the top level (1209:0)
```

# CHANGELOG
* **Updated** version of `pikaday` to pinned `1.6.1`
* **Added** bower since it is no longer included by Ember CLI